### PR TITLE
Fedora qdbus-qt6 support

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -16,7 +16,7 @@
     </entry>
     <entry name="command" type="String">
       <label>Command to execute</label>
-      <default>qdbus org.kde.kglobalaccel /component/kwin invokeShortcut Overview</default>
+      <default>qdbus-qt6 org.kde.kglobalaccel /component/kwin invokeShortcut Overview</default>
     </entry>
   </group>
 </kcfg>

--- a/metadata.json
+++ b/metadata.json
@@ -13,10 +13,10 @@
         ],
         "EnabledByDefault": true,
         "Name": "Overview",
-        "Description": "Toggle Overview",
+        "Description": "Toggle Overview on Plasma 6",
         "Id": "com.himdek.kde.plasma.overview",
         "Icon": "dialog-layers",
-        "Version": 1.4,
+        "Version": 1.5,
         "License": "GPL-3.0-or-later",
         "BugReportUrl": "https://github.com/HimDek/Overview-Widget-for-Plasma/issues/new",
         "Website": "https://himdek.com/Overview-Widget-for-Plasma/"


### PR DESCRIPTION
I confirmed that this works on Fedora 40, Plasma 6.1.x.

[overview-widget.zip](https://github.com/user-attachments/files/17374852/overview-widget.zip)

I think you cannot run if/else logic without a separate shell script

otherwise

```
#!/bin/bash

if command -v qdbus-qt6 &> /dev/null
then
    qdbus-qt6 org.kde.kglobalaccel /component/kwin invokeShortcut Overview
else
    qdbus org.kde.kglobalaccel /component/kwin invokeShortcut Overview
fi
```

main.xml

```
<?xml version="1.0" encoding="UTF-8"?>
<kcfg xmlns="http://www.kde.org/standards/kcfg/1.0"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0
      http://www.kde.org/standards/kcfg/1.0/kcfg.xsd" >
  <kcfgfile name=""/>

  <group name="General">
    <entry name="icon" type="String">
      <label>Icon</label>
      <default>dialog-layers</default>
    </entry>
    <entry name="menuLabel" type="string">
      <label>Text label</label>
      <default></default>
    </entry>
    <entry name="command" type="String">
      <label>Command to execute</label>
      <default>/path/to/run_qdbus.sh</default>
    </entry>
  </group>
</kcfg>
```

this would be a better solution but not sure where such a script would be placed.